### PR TITLE
Refactor dotnet publish command in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Publish Application
         shell: bash
         run: |
-          dotnet publish WebServer/WebServer.csproj -c Release -r ${{ matrix.rid }} --self-contained true /p:PublishSingleFile=true /p:PublishTrimmed=true /p:DebugType=None /p:DebugSymbols=false -o publish/${{ matrix.rid }}
+          dotnet publish WebServer/WebServer.csproj -c Release -r ${{ matrix.rid }} /p:SelfContained=true /p:PublishSingleFile=true /p:PublishTrimmed=true /p:DebugType=None /p:DebugSymbols=false -o publish/${{ matrix.rid }}
 
       - name: Set up Web Directory
         run: |


### PR DESCRIPTION
Updated the `dotnet publish` command to replace the `--self-contained true` option with `/p:SelfContained=true`, simplifying the command while preserving its functionality.